### PR TITLE
Library search path in `src/loadlib.jl`

### DIFF
--- a/src/loadlib.jl
+++ b/src/loadlib.jl
@@ -89,12 +89,14 @@ const simhasher_res_key = dlsym(libkey,:simhasher_res)
 const distance_key = dlsym(libkey,:distance)
 
 
+# Get the 'deps' directory path
+const deps_path = dirname(libname)
 
-DICTPATH = joinpath(Pkg.dir(), "Jieba","deps", "dict", "jieba.dict.utf8")
-HMMPATH  = joinpath(Pkg.dir(), "Jieba","deps", "dict", "hmm_model.utf8")
-USERPATH = joinpath(Pkg.dir(), "Jieba","deps", "dict", "user.dict.utf8")
-STOPPATH  = joinpath(Pkg.dir(), "Jieba","deps", "dict", "stop_words.utf8")
-IDFPATH = joinpath(Pkg.dir(), "Jieba","deps", "dict", "idf.utf8")
+DICTPATH = joinpath(deps_path, "dict", "jieba.dict.utf8")
+HMMPATH  = joinpath(deps_path, "dict", "hmm_model.utf8")
+USERPATH = joinpath(deps_path, "dict", "user.dict.utf8")
+STOPPATH  = joinpath(deps_path, "dict", "stop_words.utf8")
+IDFPATH = joinpath(deps_path, "dict", "idf.utf8")
 
 if !isfile(DICTPATH)
     error("Can not find system dictionary.")

--- a/src/loadlib.jl
+++ b/src/loadlib.jl
@@ -9,6 +9,7 @@ import Base.Libdl.dlsym
 
 fnames = ["libdemo.so", "libdemo.dylib", "libdemo.dll"]
 paths = [pwd(), joinpath(Pkg.dir(), "Jieba", "deps")]
+append!(paths, [joinpath(dir, "Jieba", "deps") for dir in Base.LOAD_PATH])
 global libname
 found = false
 for path in paths


### PR DESCRIPTION
The library loading procedure in `src/loadlib.jl` looked exclusively in `Pkg.dir()` for library files, but not from other paths such as those in `Base.LOAD_PATH`.  When installing Jieba in a shared directory (e.g. `/opt/julia/share/julia/site`) the library/dict files will also be stored alongside the package.  This pull request fixes this problem by adding `Base.LOAD_PATH` into the search path.

Note that setting env `JULIA_PKGDIR` to global directory doesn't solve this problem - one can load Jieba successfully but then fail in storing pre-compilation cache files due to the lack of write permissions to global directory.